### PR TITLE
Guard record processing against empty name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,6 +196,7 @@ async function checkForNewSubmissions() {
   base('Requests').select({ view: 'Grid view' }).eachPage(async (records, nextPage) => {
     // Look for records that have not been posted to slack yet
     for (const record of records) {
+      if (typeof record.get('Name') === 'undefined') continue;
       if (record.get('Posted to Slack?') !== 'yes') {
         log(`\nProcessing: ${record.get('Name')}`);
 


### PR DESCRIPTION
Make sure not to post an update if there is no name field entered in the
row. This should help protect against accidental entries, since Airtable
makes it easy to enter a new row.

Use an early `continue`, to prevent additional nesting, or adding
potentially confusing compound `if` clauses.