### PR TITLE
Add help to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-develop: clean build run
+develop: clean build run ## Alias for: clean build run.
 
-clean:
+help: ## Prints help for targets with comments.
+	@grep -E '^[a-zA-Z._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+clean: ## Remove stopped Docker services.
 	docker-compose rm -vf
 
-build:
+build: ## Build Docker services.
 	docker-compose build
 
-run:
+run: ## Start Docker services.
 	docker-compose up


### PR DESCRIPTION
Add `help` command to Makefile. The command parses comments attached to
each command listed in the Makefile, and prints this to the console.