### PR TITLE
Add volunteer state to Docker environment and await sending Slack messages

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,5 +16,6 @@ services:
       NODE_ENV: ${NODE_ENV:-development}
       SLACK_CHANNEL_ID: ${SLACK_CHANNEL_ID}
       SLACK_XOXB: ${SLACK_XOXB}
+      VOLUNTEER_DISPATCH_STATE: ${VOLUNTEER_DISPATCH_STATE}
     volumes:
       - "./src:/srv/src"

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@ const config = {
   // Geocoder
   GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
   MAPQUEST_KEY: process.env.MAPQUEST_KEY,
-  VOLUNTEER_DISPATCH_STATE: process.env.VOLUNTEER_DISPATCH_STATE || "NY",
+  VOLUNTEER_DISPATCH_STATE: process.env.VOLUNTEER_DISPATCH_STATE || "DC",
 
   // Airtable
   AIRTABLE_API_KEY: process.env.AIRTABLE_API_KEY,

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@ const config = {
   // Geocoder
   GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
   MAPQUEST_KEY: process.env.MAPQUEST_KEY,
-  VOLUNTEER_DISPATCH_STATE: process.env.VOLUNTEER_DISPATCH_STATE || "DC",
+  VOLUNTEER_DISPATCH_STATE: process.env.VOLUNTEER_DISPATCH_STATE || "NY",
 
   // Airtable
   AIRTABLE_API_KEY: process.env.AIRTABLE_API_KEY,

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const base = new Airtable({ apiKey: config.AIRTABLE_API_KEY }).base(
 const customAirtable = new CustomAirtable(base);
 
 function fullAddress(record) {
-  return `${record.get("Address")} ${record.get("City")}, ${record.get("State")}`;
+  return `${record.get("Address")} ${record.get("City")}, ${config.VOLUNTEER_DISPATCH_STATE}`;
 }
 
 // Accepts errand address and checks volunteer spreadsheet for closest volunteers

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,9 @@ const base = new Airtable({ apiKey: config.AIRTABLE_API_KEY }).base(
 const customAirtable = new CustomAirtable(base);
 
 function fullAddress(record) {
-  return `${record.get("Address")} ${record.get("City")}, ${config.VOLUNTEER_DISPATCH_STATE}`;
+  return `${record.get("Address")} ${record.get("City")}, ${
+    config.VOLUNTEER_DISPATCH_STATE
+  }`;
 }
 
 // Accepts errand address and checks volunteer spreadsheet for closest volunteers

--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,7 @@ const base = new Airtable({ apiKey: config.AIRTABLE_API_KEY }).base(
 const customAirtable = new CustomAirtable(base);
 
 function fullAddress(record) {
-  return `${record.get("Address")} ${record.get("City")}, ${
-    config.VOLUNTEER_DISPATCH_STATE
-  }`;
+  return `${record.get("Address")} ${record.get("City")}, ${record.get("State")}`;
 }
 
 // Accepts errand address and checks volunteer spreadsheet for closest volunteers
@@ -157,8 +155,9 @@ async function checkForNewSubmissions() {
         const volunteers = await findVolunteers(record);
 
         // Send the message to Slack
-        sendMessage(record, volunteers);
-        logger.info("Posted to Slack!");
+        await sendMessage(record, volunteers)
+          .then(logger.info("Posted to Slack!"))
+          .catch((error) => logger.error(error));
 
         await record
           .patchUpdate({


### PR DESCRIPTION
This PR addresses two issues:
- Formerly, the codebase defaulted to "NY" as the state because the Docker environment was not reading a variable for `VOLUNTEER_DISPATCH_STATE`. This change allows for a user to set the environment variable and for it to be read by the Docker instance.
- Separately, a logging message was sending that the mutual aid request was being posted to Slack even when it wasn't. This change awaits the message to post to Slack before logging that it was posted, or returns an error if the message does not post to Slack.

Thanks @azlyth for helping us get set up in DC!