### PR TITLE
Add eslint config for max line length 100

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
     "no-continue": "off",
     "no-await-in-loop": "off",
     "quote-props": "off",
-    "no-restricted-syntax": "off"
+    "no-restricted-syntax": "off",
+    "max-len": [2, {"code": 100, "tabWidth": 2, "ignoreUrls": true, "ignoreStrings": true}]
   }
 }


### PR DESCRIPTION
The `max-len` rule was not specified, and not included in
prettier/eslint defaults for some reason; tested by adding the `max-len`
rule at agreed upon 100 columns, and seeing 2 strings exceeding that
line length in dispatch.js fail.

Mark the rule as an error, but allow it to ignore long strings and URLs;
in the case of the former, we would have to change the line wrapping of
the output text if we changed the source, and that doesn't seem worth
it. URLs aren't correct if they break to a new line so those should be
excluded as well.

