### PR TITLE
Match 'other' requests

### DIFF
--- a/src/slack/dispatch.js
+++ b/src/slack/dispatch.js
@@ -11,12 +11,14 @@ const formatTasks = (record) => {
   // Put each task on a new line
   let formattedTasks = "";
   if (tasks) {
-    formattedTasks = record
-      .get("Tasks")
-      .reduce(
-        (taskList, task) => `${taskList}\n :small_orange_diamond: ${task}`,
-        ""
-      );
+    formattedTasks = record.get("Tasks").reduce((taskList, task) => {
+      let msg = `${taskList}\n :small_orange_diamond: ${task}`;
+      if (task === "Other") {
+        msg +=
+          '\n\t\t:warning: These volunteer matches are guesses, since this is an "Other" request. :warning:';
+      }
+      return msg;
+    }, "");
   }
 
   if (otherTasks) {

--- a/src/slack/dispatch.js
+++ b/src/slack/dispatch.js
@@ -15,7 +15,7 @@ const formatTasks = (record) => {
       let msg = `${taskList}\n :small_orange_diamond: ${task}`;
       if (task === "Other") {
         msg +=
-          '\n\t\t:warning: These volunteer matches are guesses, since this is an "Other" request. :warning:';
+          '\n\t\t:warning: Because this is an "Other" request, these volunteer matches might not be the best options, depending on what the request is. :warning:';
       }
       return msg;
     }, "");

--- a/src/task.js
+++ b/src/task.js
@@ -81,7 +81,13 @@ const possibleTasks = [
     "Navigating the health care/insurance websites",
   ]),
   // Set an unmatchable requirement since we don't know the nature of an "Other"
-  new Task("Other", ["unmatchable-requirement"]),
+  new Task("Other", [
+    "Meal delivery",
+    "Picking up groceries/medications",
+    "Pet-sitting/walking/feeding",
+    "Checking in on people",
+    "Donations of other kind"
+  ]),
 ];
 Task.possibleTasks = possibleTasks;
 const cache = {};

--- a/src/task.js
+++ b/src/task.js
@@ -80,7 +80,7 @@ const possibleTasks = [
     "Checking in on people",
     "Navigating the health care/insurance websites",
   ]),
-  // Set an unmatchable requirement since we don't know the nature of an "Other"
+  // Match most requirements since we don't know the nature of an "Other"
   new Task("Other", [
     "Meal delivery",
     "Picking up groceries/medications",


### PR DESCRIPTION
Find volunteers for "other" requests, and add a message to Slack warning
that this is a guess.

The "guess" message would probably be better suited above/below the
listed volunteers section, but adding it there would require refactoring
the data scope in disptach.js, so I opted instead for a lighter touch
for now.