### PR TITLE
Count volunteer's assigned tasks

### DIFF
--- a/src/slack/message/index.js
+++ b/src/slack/message/index.js
@@ -17,6 +17,11 @@ const getHeading = () => {
   return headingSection;
 };
 
+const pluralize = (num, str) => {
+  const sMaybe = num === 1 ? "" : "s";
+  return `${num} ${str}${sMaybe}`;
+};
+
 const getLanguage = (record) => {
   const languages = [record.get("Language"), record.get("Language - other")];
   const languageList = languages.filter((language) => language).join(", ");
@@ -143,7 +148,7 @@ const getVolunteerHeading = (volunteers) => {
   }
 };
 
-const getVolunteers = (volunteers) => {
+const getVolunteers = (volunteers, taskCounts) => {
   if (!volunteers.length) return;
 
   const volunteerSections = volunteers.map((volunteer) => {
@@ -154,8 +159,11 @@ const getVolunteers = (volunteers) => {
       typeof volunteer.Distance === "number"
         ? `${volunteer.Distance.toFixed(2)} Mi.`
         : "Distance N/A";
+    const taskCount = taskCounts.has(volunteer.Id)
+      ? pluralize(taskCounts.get(volunteer.Id), "assigned task")
+      : pluralize(0, "assigned task");
 
-    const volunteerLine = `:wave: ${volunteerLink}\n ${displayNumber} - ${volunteerDistance}\n`;
+    const volunteerLine = `:wave: ${volunteerLink}\n ${displayNumber} - ${volunteerDistance} - ${taskCount}\n`;
     const volunteerSection = getSection(volunteerLine);
 
     return volunteerSection;

--- a/src/slack/sendDispatch.js
+++ b/src/slack/sendDispatch.js
@@ -6,7 +6,7 @@ const message = require("./message");
 const channel = config.SLACK_CHANNEL_ID;
 
 // This function actually sends the message to the slack channel
-const sendDispatch = async (record, volunteers) => {
+const sendDispatch = async (record, volunteers, taskCounts) => {
   if (!record) throw new Error("No record passed to sendMessage().");
 
   const text = "A new errand has been added";
@@ -35,7 +35,7 @@ const sendDispatch = async (record, volunteers) => {
   });
 
   const volunteerHeading = message.getVolunteerHeading(volunteers);
-  const volunteerList = message.getVolunteers(volunteers);
+  const volunteerList = message.getVolunteers(volunteers, taskCounts);
   const volunteerClosing = message.getVolunteerClosing(volunteers);
 
   await bot.chat.postMessage({


### PR DESCRIPTION
This implementation gets the total amount of volunteers and sets that to
a `Map`, with the user id as the key and the count of their tasks as the
value.

This Map is then passed through the function chain to end up in dispatch
where each volunteer's id is retrieved from the Map to get the amount of
tasks assigned. This scope passing as function argument could be made
more elegant.

Also, re-work the Airtable queries to grab only the data we need,
instead of doing the filtering after the fact.

On a small note, replace the `volunteerLine` constant with a direct
`return`. While the intermediate constant is not necessary, the real
reason to do this was to make ESLint happy with max line length.