### PR TITLE
Change how request task splitting works

### DIFF
--- a/src/airtable-utils.js
+++ b/src/airtable-utils.js
@@ -53,6 +53,7 @@ class AirtableUtils {
     preconditions.shouldBeString(order);
     const fields = {
       ...request.rawFields,
+      "Original Tasks": request.rawFields.Tasks,
       Tasks: [task.rawTask],
       "Cloned from": [request.id],
       "Task Order": order,

--- a/src/index.js
+++ b/src/index.js
@@ -171,13 +171,12 @@ async function checkForNewSubmissions() {
       view: config.AIRTABLE_REQUESTS_VIEW_NAME,
       filterByFormula: `
         AND(
-          {Was split?} != 'yes', 
-          {Name} != '', 
-          OR(      
+          {Name} != '',
+          OR(
             {Posted to Slack?} != 'yes',
             AND(
               {Posted to Slack?} = 'yes',
-              {Reminder Posted} != 'yes',      
+              {Reminder Posted} != 'yes',
               AND(
                 {Reminder Date/Time} != '',
                 {Reminder Date/Time} < ${Date.now()}

--- a/test/service/request-service.test.js
+++ b/test/service/request-service.test.js
@@ -17,6 +17,7 @@ describe("RequestService", () => {
     mockAirtableRequest = {
       id: "lkdjf8979",
       get: mockAirtableGet,
+      fields: {},
     };
     service = new RequestService(base);
   });
@@ -43,13 +44,17 @@ describe("RequestService", () => {
     });
     it("should try to create correct records", async () => {
       expect.assertions(1);
+      mockAirtableRequest.fields.Tasks = [
+        Task.possibleTasks[0],
+        Task.possibleTasks[1],
+      ];
       when(mockAirtableGet)
         .calledWith("Tasks")
         .mockReturnValue([Task.possibleTasks[0], Task.possibleTasks[1]]);
       const request = new RequestRecord(mockAirtableRequest);
       const newRecords = [
-        { fields: { Task: Task.possibleTasks[0] } },
-        { fields: { Task: Task.possibleTasks[1] } },
+        { fields: { Tasks: Task.possibleTasks[0] } },
+        { fields: { Tasks: Task.possibleTasks[1] } },
       ];
       AirtableUtils.cloneRequestFieldsWithGivenTask.mockReturnValueOnce(
         newRecords[0]
@@ -58,7 +63,7 @@ describe("RequestService", () => {
         newRecords[1]
       );
       await service.splitMultiTaskRequest(request);
-      expect(base.create).toHaveBeenCalledWith(newRecords);
+      expect(base.create).toHaveBeenCalledWith([newRecords[0]]);
     });
   });
 });


### PR DESCRIPTION
Instead of creating new records for each individual request, then
marking the original record as "Was split", modify the original
request's "Tasks" field to use only the first task listed, then create
new records for any subsequent tasks.

This is done because the "Was split" field often gets deleted, or
filters do no use it. This shows the original record, any it appears as
a duplicate and unwanted noise.

Update a new "Original Tasks" field with all the tasks, un-split, input
in the original request. Add these tasks to each split record as well as
the original, for tracking purposes.