### PR TITLE
Display Task Order for split tasks

### DIFF
--- a/src/airtable-utils.js
+++ b/src/airtable-utils.js
@@ -50,6 +50,7 @@ class AirtableUtils {
     preconditions.shouldBeDefined(request.id);
     preconditions.shouldBeObject(request.rawFields);
     preconditions.shouldBeObject(task);
+    preconditions.shouldBeString(order);
     const fields = {
       ...request.rawFields,
       Tasks: [task.rawTask],

--- a/src/airtable-utils.js
+++ b/src/airtable-utils.js
@@ -30,10 +30,12 @@ class AirtableUtils {
    * field with the given task.
    * @param request {RequestRecord} Request whose fields you want to clone
    * @param task {Task} Task to be set
-   * @returns {{fields: {Tasks: string[], "Cloned from": string[]}}} along with
+   * @param order {string} String that indicates the order of given task
+   * relative to other tasks in the request
+   * @returns {{fields: {Tasks: string[], "Cloned from": string[], "Task Order": string[]}}} along with
    * properties from the original request
    */
-  static cloneRequestFieldsWithGivenTask(request, task) {
+  static cloneRequestFieldsWithGivenTask(request, task, order) {
     preconditions.shouldBeObject(request);
     preconditions.shouldBeDefined(request.id);
     preconditions.shouldBeObject(request.rawFields);
@@ -42,6 +44,7 @@ class AirtableUtils {
       ...request.rawFields,
       Tasks: [task.rawTask],
       "Cloned from": [request.id],
+      "Task Order": order
     };
     delete fields["Created time"];
     delete fields["Record ID"];

--- a/src/service/request-service.js
+++ b/src/service/request-service.js
@@ -112,8 +112,12 @@ class RequestService {
     preconditions.shouldBeObject(request);
     preconditions.checkArgument(request.tasks.length > 1);
     const newRecordsPerTask = request.tasks.map((task, idx) => {
-      const order = `${idx + 1} of ${request.tasks.length}`
-      return AirtableUtils.cloneRequestFieldsWithGivenTask(request, task, order)
+      const order = `${idx + 1} of ${request.tasks.length}`;
+      return AirtableUtils.cloneRequestFieldsWithGivenTask(
+        request,
+        task,
+        order
+      );
     });
     try {
       await this.base.create(newRecordsPerTask);

--- a/src/service/request-service.js
+++ b/src/service/request-service.js
@@ -107,9 +107,10 @@ class RequestService {
   async splitMultiTaskRequest(request) {
     preconditions.shouldBeObject(request);
     preconditions.checkArgument(request.tasks.length > 1);
-    const newRecordsPerTask = request.tasks.map((task) =>
-      AirtableUtils.cloneRequestFieldsWithGivenTask(request, task)
-    );
+    const newRecordsPerTask = request.tasks.map((task, idx) => {
+      const order = `${idx + 1} of ${request.tasks.length}`
+      return AirtableUtils.cloneRequestFieldsWithGivenTask(request, task, order)
+    });
     try {
       await this.base.create(newRecordsPerTask);
       this.markRequestAsSplit(request);

--- a/src/slack/message/index.js
+++ b/src/slack/message/index.js
@@ -45,6 +45,12 @@ const getHeading = (options) => {
   return getSection(`:exclamation: *${options.text}* :exclamation:`);
 };
 
+/**
+ * Format task order for split tasks.
+ *
+ * @param {object} record The split task to get order from.
+ * @returns {string} The formatted task order to display after message header.
+ */
 const getTaskOrder = (record) => {
   if (record.get("Task Order")) {
     return getSection(

--- a/src/slack/message/index.js
+++ b/src/slack/message/index.js
@@ -35,7 +35,7 @@ const getText = (options) => {
  * @param {object} options The configuration options.
  * @param {string} options.text The message to format.
  * @param {boolean} options.reminder Whether this message is a reminder or not.
- * @returns {string} The formatted heading.
+ * @returns {object} The formatted heading.
  */
 const getHeading = (options) => {
   if (options.reminder) {
@@ -49,7 +49,7 @@ const getHeading = (options) => {
  * Format task order for split tasks.
  *
  * @param {object} record The split task to get order from.
- * @returns {string} The formatted task order to display after message header.
+ * @returns {object} The formatted task order to display after message header.
  */
 const getTaskOrder = (record) => {
   if (record.get("Task Order")) {

--- a/src/slack/message/index.js
+++ b/src/slack/message/index.js
@@ -25,6 +25,12 @@ const getHeading = (options) => {
   return getSection(`:exclamation: *${options.text}* :exclamation:`);
 };
 
+const getTaskOrder = (record) => {
+  if (record.get("Task Order")) {
+    return getSection(`:bellhop_bell: This is *Task ${record.get("Task Order")}* of the Request`);
+  }
+}
+
 const pluralize = (num, str) => {
   const sMaybe = num === 1 ? "" : "s";
   return `${num} ${str}${sMaybe}`;
@@ -218,6 +224,7 @@ const getCopyPasteNumbers = (volunteers) => {
 module.exports = {
   getText,
   getHeading,
+  getTaskOrder,
   getRequester,
   getTasks,
   getTimeframe,

--- a/src/slack/sendDispatch.js
+++ b/src/slack/sendDispatch.js
@@ -20,14 +20,15 @@ const sendPrimaryRequestInfo = async (record, text, reminder) => {
   const requester = message.getRequester(record);
   const tasks = message.getTasks(record);
   const requestedTimeframe = message.getTimeframe(record);
+  const blocks = taskOrder
+    ? [heading, taskOrder, requester, tasks, requestedTimeframe, followUpButton]
+    : [heading, requester, tasks, requestedTimeframe, followUpButton];
 
   const res = await bot.chat.postMessage({
     token,
     channel,
     text,
-    blocks: taskOrder ?
-      [heading, taskOrder, requester, tasks, requestedTimeframe, followUpButton] :
-      [heading, requester, tasks, requestedTimeframe, followUpButton],
+    blocks,
   });
 
   return res;

--- a/src/slack/sendDispatch.js
+++ b/src/slack/sendDispatch.js
@@ -8,6 +8,7 @@ const channel = config.SLACK_CHANNEL_ID;
 
 const sendPrimaryRequestInfo = async (record, text, reminder) => {
   const heading = message.getHeading({ reminder, text });
+  const taskOrder = message.getTaskOrder(record);
   const requester = message.getRequester(record);
   const tasks = message.getTasks(record);
   const requestedTimeframe = message.getTimeframe(record);
@@ -16,7 +17,9 @@ const sendPrimaryRequestInfo = async (record, text, reminder) => {
     token,
     channel,
     text,
-    blocks: [heading, requester, tasks, requestedTimeframe, followUpButton],
+    blocks: taskOrder ?
+      [heading, taskOrder, requester, tasks, requestedTimeframe, followUpButton] :
+      [heading, requester, tasks, requestedTimeframe, followUpButton],
   });
 
   return res;

--- a/test/airtable-utils.test.js
+++ b/test/airtable-utils.test.js
@@ -1,20 +1,26 @@
+/* eslint-disable max-len */
+/* To allow test case table to pass linting */
+
 const AirtableUtils = require("../src/airtable-utils");
 const RequestRecord = require("../src/model/request-record");
 const Task = require("../src/task");
 
 describe("AirtableUtils", () => {
   describe("cloneRequestFieldsWithGivenTask", () => {
+    const taskOrder = "1 of 3";
     it.each`
-      request                                              | task         | expectedError
-      ${undefined}                                         | ${undefined} | ${"Variable should be of type Object."}
-      ${{ id: "kjhs8090" }}                                | ${undefined} | ${"Variable should be of type Object."}
-      ${{}}                                                | ${undefined} | ${"Variable should be defined."}
-      ${new RequestRecord({ id: "kjhs8090", fields: {} })} | ${undefined} | ${"Variable should be of type Object."}
+      request                                              | task         | order        | expectedError
+      ${undefined}                                         | ${undefined} | ${taskOrder} | ${"Variable should be of type Object."}
+      ${{ id: "kjhs8090" }}                                | ${undefined} | ${taskOrder} | ${"Variable should be of type Object."}
+      ${{}}                                                | ${undefined} | ${taskOrder} | ${"Variable should be defined."}
+      ${new RequestRecord({ id: "kjhs8090", fields: {} })} | ${undefined} | ${taskOrder} | ${"Variable should be of type Object."}
+      ${new RequestRecord({ id: "kjhs8090", fields: {} })} | ${undefined} | ${taskOrder} | ${"Variable should be of type Object."}
+      ${new RequestRecord({ id: "kjhs8090", fields: {} })} | ${{}}        | ${undefined} | ${"Variable should be a String."}
     `(
       "should throw in case of invalid arguments",
-      ({ request, task, expectedError }) => {
+      ({ request, task, order, expectedError }) => {
         expect(() =>
-          AirtableUtils.cloneRequestFieldsWithGivenTask(request, task)
+          AirtableUtils.cloneRequestFieldsWithGivenTask(request, task, order)
         ).toThrow(expectedError);
       }
     );
@@ -42,7 +48,8 @@ describe("AirtableUtils", () => {
       (request) => {
         const clonedRequest = AirtableUtils.cloneRequestFieldsWithGivenTask(
           request,
-          Task.possibleTasks[0]
+          Task.possibleTasks[0],
+          taskOrder
         );
         expect(clonedRequest.fields).not.toHaveProperty("Created time");
         expect(clonedRequest.fields).not.toHaveProperty("Error");
@@ -69,7 +76,8 @@ describe("AirtableUtils", () => {
       const task = Task.possibleTasks[0];
       const clonedRequest = AirtableUtils.cloneRequestFieldsWithGivenTask(
         request,
-        task
+        task,
+        taskOrder
       );
       expect(clonedRequest.fields).toHaveProperty("Tasks");
       expect(clonedRequest.fields.Tasks).toEqual([task.rawTask]);
@@ -85,7 +93,8 @@ describe("AirtableUtils", () => {
       expect(
         AirtableUtils.cloneRequestFieldsWithGivenTask(
           givenRequest,
-          Task.possibleTasks[0]
+          Task.possibleTasks[0],
+          taskOrder
         ).fields
       ).toEqual(expect.objectContaining(givenRequest.rawFields));
     });
@@ -95,9 +104,21 @@ describe("AirtableUtils", () => {
       expect(
         AirtableUtils.cloneRequestFieldsWithGivenTask(
           request,
-          Task.possibleTasks[0]
+          Task.possibleTasks[0],
+          "1 of 3"
         ).fields["Cloned from"]
       ).toEqual([id]);
+    });
+    it("should set the 'Task Order' field with the task order string", () => {
+      const id = "jsdhf9329";
+      const request = new RequestRecord({ fields: {}, id });
+      expect(
+        AirtableUtils.cloneRequestFieldsWithGivenTask(
+          request,
+          Task.possibleTasks[0],
+          taskOrder
+        ).fields["Task Order"]
+      ).toEqual(taskOrder);
     });
   });
 });

--- a/test/slack/message/index.test.js
+++ b/test/slack/message/index.test.js
@@ -15,6 +15,7 @@ class MockRequestRecord {
       Address: "25-82 36th Street",
       Status: "Needs assigning",
       Tasks: ["Dog walking"],
+      "Task Order": "2 of 3",
     };
   }
 
@@ -149,6 +150,24 @@ describe("The primary message", () => {
     expect(headingSection.text.text).toEqual(
       expect.stringContaining("Reminder for a previous request")
     );
+  });
+
+  describe("Task order", () => {
+    test("If task is split from a multi-task request, display task order", () => {
+      const requester = new MockRequestRecord();
+      const taskOrderSection = message.getTaskOrder(requester);
+
+      expect(taskOrderSection.text.text).toEqual(
+        expect.stringContaining(requester.get("Task Order"))
+      );
+    });
+
+    test("The task order info should be a section", () => {
+      const requester = new MockRequestRecord();
+      const taskOrderSection = message.getTaskOrder(requester);
+
+      expect(validateSection(taskOrderSection)).toBe(true);
+    });
   });
 
   describe("Requester info", () => {


### PR DESCRIPTION
This feature adds a line to the request message in Slack displaying the **Task Order** of a task that has been split off from a multi-task request.

Previously there was no clear indication that a task was part of a multi-task request.

## Before
> <img width="367" alt="Screen Shot 2020-05-19 at 10 44 20 PM" src="https://user-images.githubusercontent.com/6953434/82399112-60b10180-9a22-11ea-95af-9fc420708539.png">

## After
> <img width="394" alt="Screen Shot 2020-05-19 at 10 50 10 PM" src="https://user-images.githubusercontent.com/6953434/82399442-27c55c80-9a23-11ea-9978-b3f177b83921.png">

## Airtable Requirements
This feature requires that a field called `Task Order` of type **Single Line Text** be added to the `Requests` table. Additionally it requires that the table be sorted by `Created Time`, then by `Task Order`.

> <img width="436" alt="Screen Shot 2020-05-19 at 10 39 17 PM" src="https://user-images.githubusercontent.com/6953434/82398878-df596f00-9a21-11ea-8b00-0402e5439979.png">
