### PR TITLE
Last date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5980,11 +5980,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true,
-      "optional": true
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "express": "^4.17.1",
     "geolib": "^3.2.1",
     "google-libphonenumber": "^3.2.8",
+    "moment": "^2.26.0",
     "node-geocoder": "^3.25.1",
     "preconditions": "^2.2.3",
-    "random-js": "^2.1.0",
     "qs": "^6.9.3",
+    "random-js": "^2.1.0",
     "slack": "^11.0.2",
     "winston": "^3.2.1",
     "winston-transport": "^4.3.0"

--- a/src/index.js
+++ b/src/index.js
@@ -189,9 +189,7 @@ async function checkForNewSubmissions() {
       if (!records.length) return;
 
       const newSubmissions = records.map((r) => new Request(r));
-
-      // Get the amount of tasks assigned to each volunteer
-      const volunteerTaskCounts = await requestService.getVolunteerTaskCounts();
+      const volunteerTaskStats = await requestService.getVolunteerTaskStats();
 
       // Look for records that have not been posted to slack yet
       for (const record of newSubmissions) {
@@ -229,7 +227,7 @@ async function checkForNewSubmissions() {
             await sendDispatch(
               requestWithCoords,
               volunteers,
-              volunteerTaskCounts,
+              volunteerTaskStats,
               true
             );
             reminder = true;
@@ -237,7 +235,7 @@ async function checkForNewSubmissions() {
             await sendDispatch(
               requestWithCoords,
               volunteers,
-              volunteerTaskCounts
+              volunteerTaskStats
             );
           }
 

--- a/src/index.js
+++ b/src/index.js
@@ -186,13 +186,15 @@ async function checkForNewSubmissions() {
         )`,
     })
     .eachPage(async (records, nextPage) => {
-      const mappedRecords = records.map((r) => new Request(r));
+      if (!records.length) return;
+
+      const newSubmissions = records.map((r) => new Request(r));
 
       // Get the amount of tasks assigned to each volunteer
       const volunteerTaskCounts = await requestService.getVolunteerTaskCounts();
 
       // Look for records that have not been posted to slack yet
-      for (const record of mappedRecords) {
+      for (const record of newSubmissions) {
         let requestWithCoords;
         try {
           requestWithCoords = await requestService.resolveAndUpdateCoords(

--- a/src/service/request-service.js
+++ b/src/service/request-service.js
@@ -132,7 +132,7 @@ class RequestService {
   /**
    * Gets stats related to a volunteer's assigned tasks.
    *
-   * @returns {Map.<string, {count: number, lastDate: string}>} A map of volunteer keys and task stats.
+   * @returns {Map.<string, {count: number, lastDate: string}>} Volunteer ids and task stats.
    */
   async getVolunteerTaskStats() {
     const taskStats = new Map();
@@ -147,7 +147,7 @@ class RequestService {
           const recordCreatedTime = record.get("Created time");
           const volunteerIds = record.get("Assigned Volunteer");
 
-          volunteerIds.map((id) => {
+          volunteerIds.forEach((id) => {
             if (!taskStats.has(id)) {
               taskStats.set(id, { count: 1, lastDate: recordCreatedTime });
             } else {

--- a/src/service/request-service.js
+++ b/src/service/request-service.js
@@ -135,26 +135,30 @@ class RequestService {
    * @returns {Map.<string, number>} A map of volunteer keys and task count values.
    */
   async getVolunteerTaskCounts() {
-    const volunteerCounts = new Map();
+    const taskCounts = new Map();
+
     await this.base
       .select({
         view: config.AIRTABLE_REQUESTS_VIEW_NAME,
-        filterByFormula:
-          "AND({Status} != 'Completed', {Assigned Volunteer} != '')",
+        filterByFormula: "{Assigned Volunteer} != ''",
       })
       .eachPage(async (records, nextPage) => {
         records.forEach((record) => {
-          const volunteerReference = record.get("Assigned Volunteer")[0];
-          if (volunteerCounts.has(volunteerReference)) {
-            const amount = volunteerCounts.get(volunteerReference);
-            volunteerCounts.set(volunteerReference, amount + 1);
-          } else {
-            volunteerCounts.set(volunteerReference, 1);
-          }
+          const volunteerIds = record.get("Assigned Volunteer");
+
+          volunteerIds.map((id) => {
+            if (taskCounts.has(id)) {
+              const count = taskCounts.get(id);
+              taskCounts.set(id, count + 1);
+            } else {
+              taskCounts.set(id, 1);
+            }
+          });
         });
         nextPage();
       });
-    return volunteerCounts;
+
+    return taskCounts;
   }
 }
 

--- a/src/slack/message/date-utils.js
+++ b/src/slack/message/date-utils.js
@@ -1,0 +1,15 @@
+const moment = require("moment");
+
+/**
+ * Get the amount of time passed from a date until now.
+ *
+ * @param {string} date Date string as returned from Airtable.
+ * @returns {string} A colloquial express of ellapsed time (e.g., 2 months ago)
+ */
+const getElapsedTime = (date) => {
+  return moment(date).fromNow();
+};
+
+module.exports = {
+  getElapsedTime,
+};

--- a/src/slack/message/index.js
+++ b/src/slack/message/index.js
@@ -261,11 +261,11 @@ const getVolunteerHeading = (volunteers) => {
  * Format volunteer section for slack.
  *
  * @param {Array} volunteers The volunteers to format the heading for.
- * @param {Map} taskCounts A map of volunteers to the amount of their assigned tasks.
- * @returns {Array} The formatted volunteer section object.
+ * @param {Map} taskStats Volunteer IDs mapped to stats about tasks they've been assigned.
+ * @returns {Array} A array of formatted volunteer section objects.
  */
-const getVolunteers = (volunteers, taskCounts) => {
-  if (!volunteers || !volunteers.length || !taskCounts) {
+const getVolunteers = (volunteers, taskStats) => {
+  if (!volunteers || !volunteers.length || !taskStats) {
     const noneFoundText =
       "*No volunteers match this request!*\n*Check the full Airtable record, there might be more info there.*";
 
@@ -280,13 +280,24 @@ const getVolunteers = (volunteers, taskCounts) => {
       typeof volunteer.Distance === "number"
         ? `${volunteer.Distance.toFixed(2)} Mi.`
         : "Distance N/A";
-    const taskCount = taskCounts.has(volunteer.Id)
-      ? pluralize(taskCounts.get(volunteer.Id), "assigned task")
-      : pluralize(0, "assigned task");
 
-    const volunteerLine = `:wave: ${volunteerLink}\n 
-    ${displayNumber} - ${volunteerDistance} - ${taskCount}`;
-    const volunteerSection = getSection(volunteerLine);
+    let count, lastDate;
+    if (taskStats.has(volunteer.Id)) {
+      const stats = taskStats.get(volunteer.Id);
+
+      count = `${stats.count} assigned`;
+      lastDate = `(last on ${new Date(stats.lastDate).toLocaleDateString()})`;
+    } else {
+      count = "0 assigned";
+      lastDate = "";
+    }
+
+    const volunteerDetails =
+      `:wave: ${volunteerLink}\n` +
+      `:pushpin: ${displayNumber} - ${volunteerDistance}\n` +
+      `:chart_with_upwards_trend: ${count} ${lastDate}\n`;
+
+    const volunteerSection = getSection(volunteerDetails);
 
     return volunteerSection;
   });

--- a/src/slack/sendDispatch.js
+++ b/src/slack/sendDispatch.js
@@ -59,14 +59,14 @@ const sendSecondaryRequestInfo = async (record, text, threadTs) => {
  * Send volunteer info.
  *
  * @param {Array} volunteers The list of identified volunteers.
- * @param {Map} taskCounts Map of volunteers to the amount of assigned tasks.
+ * @param {Map} taskStats Volunteer IDs mapped to stats about tasks they've been assigned.
  * @param {string} text The message to send to slack.
  * @param {string} threadTs The threaded message object returned from slack.
  * @returns {object} The slack chat message object sent.
  */
-const sendVolunteerInfo = async (volunteers, taskCounts, text, threadTs) => {
+const sendVolunteerInfo = async (volunteers, taskStats, text, threadTs) => {
   const volunteerHeading = message.getVolunteerHeading(volunteers);
-  const volunteerList = message.getVolunteers(volunteers, taskCounts);
+  const volunteerList = message.getVolunteers(volunteers, taskStats);
   const volunteerClosing = message.getVolunteerClosing(volunteers);
 
   return bot.chat.postMessage({
@@ -101,7 +101,7 @@ const sendCopyPasteNumbers = async (volunteers, threadTs) => {
  *
  * @param {object} record The Airtable record to use.
  * @param {Array} volunteers The volunteer list selected.
- * @param {Map} taskCounts Volunteers mapped to the amount of tasks they're already assigned.
+ * @param {Map} taskStats Volunteer IDs mapped to stats about tasks they've been assigned.
  * @param {boolean} [reminder] Whether this is a reminder task. Defaults to false.
  * @throws {Error} If no record is provided.
  * @returns {void}
@@ -109,7 +109,7 @@ const sendCopyPasteNumbers = async (volunteers, threadTs) => {
 const sendDispatch = async (
   record,
   volunteers,
-  taskCounts,
+  taskStats,
   reminder = false
 ) => {
   if (!record) throw new Error("No record passed to sendMessage().");
@@ -117,7 +117,7 @@ const sendDispatch = async (
   const text = message.getText({ reminder });
   const { ts } = await sendPrimaryRequestInfo(record, text, reminder);
   await sendSecondaryRequestInfo(record, text, ts);
-  await sendVolunteerInfo(volunteers, taskCounts, text, ts);
+  await sendVolunteerInfo(volunteers, taskStats, text, ts);
   await sendCopyPasteNumbers(volunteers, ts);
 };
 


### PR DESCRIPTION
# Changes
- Adds the date of the last assigned task to volunteer stats
- Tightens up the volunteer info formatting
- Displays tally of all-time total tasks assigned per volunteer (previously was only showing tally of open assigned tasks)
- Ensures that all volunteers assigned to a task are counted (previously was only counting the first volunteer) 
- Vastly reduces number of unneeded calls to Airtable API by short-circuiting `checkForNewSubmissions()` if no new submissions are found

# Volunteer info formatting
Previous:
<img width="319" alt="Screen Shot 2020-05-30 at 23 08 55" src="https://user-images.githubusercontent.com/1370591/83343623-d773b780-a2ca-11ea-9132-753ffbb1c79a.png">

New:
<img width="317" alt="Screen Shot 2020-05-30 at 23 09 13" src="https://user-images.githubusercontent.com/1370591/83343627-de022f00-a2ca-11ea-9c25-3d37f3e84435.png">
