### PR TITLE
Updated to use columns for request count and last assigned instead of computation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,6 @@ async function checkForNewSubmissions() {
       if (!records.length) return;
 
       const newSubmissions = records.map((r) => new Request(r));
-      const volunteerTaskStats = await requestService.getVolunteerTaskStats();
 
       // Look for records that have not been posted to slack yet
       for (const record of newSubmissions) {
@@ -252,19 +251,10 @@ async function checkForNewSubmissions() {
             Date.now() > record.get("Reminder Date/Time") &&
             record.get("Posted to Slack?") === "yes"
           ) {
-            await sendDispatch(
-              requestWithCoords,
-              volunteers,
-              volunteerTaskStats,
-              true
-            );
+            await sendDispatch(requestWithCoords, volunteers, true);
             reminder = true;
           } else {
-            await sendDispatch(
-              requestWithCoords,
-              volunteers,
-              volunteerTaskStats
-            );
+            await sendDispatch(requestWithCoords, volunteers);
           }
 
           messageSent = true;

--- a/src/service/request-service.js
+++ b/src/service/request-service.js
@@ -139,48 +139,6 @@ class RequestService {
   }
 
   /**
-   * Gets stats related to a volunteer's assigned tasks.
-   *
-   * @returns {Map.<string, {count: number, lastDate: string}>} Volunteer ids and task stats.
-   */
-  async getVolunteerTaskStats() {
-    const taskStats = new Map();
-
-    await this.base
-      .select({
-        view: config.AIRTABLE_REQUESTS_VIEW_NAME,
-        filterByFormula: "{Assigned Volunteer} != ''",
-      })
-      .eachPage(async (records, nextPage) => {
-        records.forEach((record) => {
-          const recordCreatedTime = record.get("Created time");
-          const volunteerIds = record.get("Assigned Volunteer");
-
-          volunteerIds.forEach((id) => {
-            if (!taskStats.has(id)) {
-              taskStats.set(id, { count: 1, lastDate: recordCreatedTime });
-            } else {
-              const { count, lastDate } = taskStats.get(id);
-
-              if (lastDate < recordCreatedTime) {
-                taskStats.set(id, {
-                  count: count + 1,
-                  lastDate: recordCreatedTime,
-                });
-              } else {
-                taskStats.set(id, { count: count + 1, lastDate });
-              }
-            }
-          });
-        });
-
-        nextPage();
-      });
-
-    return taskStats;
-  }
-
-  /**
    * Links a user to the request.
    * We try to identify the User by the requester's phone number first, followed by name.
    * A new user is created if they don't already exist in the system.

--- a/src/slack/message/index.js
+++ b/src/slack/message/index.js
@@ -262,19 +262,17 @@ const formatDistance = (distance) => {
 /**
  * Format volunteer stats for display in Slack message.
  *
- * @param {string} Volunteer's Airtable ID.
- * @param volunteerId
- * @param {Map} taskStats Volunteer IDs mapped to stats about tasks they've been assigned.
+ * @param {object} volunteer Volunteer's Airtable record.
  * @returns {object} Volunteer stats formatted for display in Slack message.
  */
-const formatStats = (volunteerId, taskStats) => {
+const formatStats = (volunteer) => {
   let count;
   let lastDate;
-  if (taskStats.has(volunteerId)) {
-    const stats = taskStats.get(volunteerId);
-
-    count = `${stats.count} assigned`;
-    lastDate = `(last ${getElapsedTime(stats.lastDate)})`;
+  const { record } = volunteer;
+  const requests = record.get("Requests count");
+  if (requests > 0) {
+    count = `${requests} assigned`;
+    lastDate = `(last ${getElapsedTime(record.get("Latest Request"))})`;
   } else {
     count = "0 assigned";
     lastDate = "";
@@ -287,11 +285,10 @@ const formatStats = (volunteerId, taskStats) => {
  * Format volunteer section for slack.
  *
  * @param {Array} volunteers The volunteers to format the heading for.
- * @param {Map} taskStats Volunteer IDs mapped to stats about tasks they've been assigned.
  * @returns {Array} A array of formatted volunteer section objects.
  */
-const getVolunteers = (volunteers, taskStats) => {
-  if (!volunteers || !volunteers.length || !taskStats) {
+const getVolunteers = (volunteers) => {
+  if (!volunteers || !volunteers.length) {
     const noneFoundText =
       "*No volunteers match this request!*\n*Check the full Airtable record, there might be more info there.*";
 
@@ -306,7 +303,7 @@ const getVolunteers = (volunteers, taskStats) => {
     const volunteerLanguage = volunteer.Language
       ? volunteer.Language
       : "English";
-    const displayStats = formatStats(volunteer.Id, taskStats);
+    const displayStats = formatStats(volunteer);
 
     const volunteerDetails =
       `:wave: ${volunteerLink}\n` +

--- a/src/slack/sendDispatch.js
+++ b/src/slack/sendDispatch.js
@@ -59,14 +59,13 @@ const sendSecondaryRequestInfo = async (record, text, threadTs) => {
  * Send volunteer info.
  *
  * @param {Array} volunteers The list of identified volunteers.
- * @param {Map} taskStats Volunteer IDs mapped to stats about tasks they've been assigned.
  * @param {string} text The message to send to slack.
  * @param {string} threadTs The threaded message object returned from slack.
  * @returns {object} The slack chat message object sent.
  */
-const sendVolunteerInfo = async (volunteers, taskStats, text, threadTs) => {
+const sendVolunteerInfo = async (volunteers, text, threadTs) => {
   const volunteerHeading = message.getVolunteerHeading(volunteers);
-  const volunteerList = message.getVolunteers(volunteers, taskStats);
+  const volunteerList = message.getVolunteers(volunteers);
   const volunteerClosing = message.getVolunteerClosing(volunteers);
 
   return bot.chat.postMessage({
@@ -101,23 +100,17 @@ const sendCopyPasteNumbers = async (volunteers, threadTs) => {
  *
  * @param {object} record The Airtable record to use.
  * @param {Array} volunteers The volunteer list selected.
- * @param {Map} taskStats Volunteer IDs mapped to stats about tasks they've been assigned.
  * @param {boolean} [reminder] Whether this is a reminder task. Defaults to false.
  * @throws {Error} If no record is provided.
  * @returns {void}
  */
-const sendDispatch = async (
-  record,
-  volunteers,
-  taskStats,
-  reminder = false
-) => {
+const sendDispatch = async (record, volunteers, reminder = false) => {
   if (!record) throw new Error("No record passed to sendMessage().");
 
   const text = message.getText({ reminder });
   const { ts } = await sendPrimaryRequestInfo(record, text, reminder);
   await sendSecondaryRequestInfo(record, text, ts);
-  await sendVolunteerInfo(volunteers, taskStats, text, ts);
+  await sendVolunteerInfo(volunteers, text, ts);
   await sendCopyPasteNumbers(volunteers, ts);
 };
 

--- a/test/slack/message/index.test.js
+++ b/test/slack/message/index.test.js
@@ -31,7 +31,7 @@ class MockRequestRecord {
 
 const mockVolunteers = [
   {
-    record: { id: 42 },
+    record: { id: 42, get: () => 0 },
     Id: 24,
     Name: "Jan",
     Distance: 4.2,
@@ -39,7 +39,7 @@ const mockVolunteers = [
     Language: "Greek",
   },
   {
-    record: { id: 42 },
+    record: { id: 42, get: () => 0 },
     Id: 25,
     Name: "Joe",
     Distance: 4.2,
@@ -47,7 +47,7 @@ const mockVolunteers = [
     Language: "Greek",
   },
   {
-    record: { id: 42 },
+    record: { id: 42, get: () => 0 },
     Id: 26,
     Name: "Mary",
     Distance: 4.2,
@@ -55,7 +55,7 @@ const mockVolunteers = [
     Language: "Spanish",
   },
   {
-    record: { id: 42 },
+    record: { id: 42, get: () => 0 },
     Id: 27,
     Name: "Jill",
     Distance: 4.2,
@@ -63,7 +63,7 @@ const mockVolunteers = [
     Language: "Spanish",
   },
   {
-    record: { id: 42 },
+    record: { id: 42, get: () => 0 },
     Id: 28,
     Name: "Steven",
     Distance: 4.2,
@@ -71,7 +71,7 @@ const mockVolunteers = [
     Language: "Bengali",
   },
   {
-    record: { id: 42 },
+    record: { id: 42, get: () => 0 },
     Id: 29,
     Name: "Nancy",
     Distance: 4.2,
@@ -79,7 +79,7 @@ const mockVolunteers = [
     Language: "Urdu",
   },
   {
-    record: { id: 42 },
+    record: { id: 42, get: () => 0 },
     Id: 30,
     Name: "Jane",
     Distance: 4.2,
@@ -87,7 +87,7 @@ const mockVolunteers = [
     Language: "Italian",
   },
   {
-    record: { id: 42 },
+    record: { id: 42, get: () => 0 },
     Id: 31,
     Name: "Anthony",
     Distance: 4.2,
@@ -95,7 +95,7 @@ const mockVolunteers = [
     Language: "English",
   },
   {
-    record: { id: 42 },
+    record: { id: 42, get: () => 0 },
     Id: 32,
     Name: "Jason",
     Distance: 4.2,


### PR DESCRIPTION
Needs two columns on the "Volunteers" table before this can be deployed:

1. Requests count
<img width="459" alt="image" src="https://user-images.githubusercontent.com/1997056/85479185-b0d43400-b58b-11ea-9e0f-8a09b74b92db.png">

2. Latest Request
<img width="534" alt="image" src="https://user-images.githubusercontent.com/1997056/85479257-d19c8980-b58b-11ea-8bfa-7d02318df94e.png">


