### PR TITLE
Add car emoji to volunteer display

### DIFF
--- a/src/slack/message/index.js
+++ b/src/slack/message/index.js
@@ -249,8 +249,7 @@ const getVolunteerHeading = (volunteers) => {
 /**
  * Format the volunteer's distance for display in Slack message.
  *
- * @param distance
- * @param {number} Volunteer's distance from request.
+ * @param {number} distance Volunteer's distance from request.
  * @returns {string} Distance formatted for display in Slack message.
  */
 const formatDistance = (distance) => {
@@ -304,9 +303,16 @@ const getVolunteers = (volunteers) => {
       ? volunteer.Language
       : "English";
     const displayStats = formatStats(volunteer);
+    const hasCar = Array.from(
+      volunteer.record.get(
+        "Do you have a private mode of transportation with valid license/insurance? "
+      )
+    ).includes("Yes, I have a car")
+      ? " :car:"
+      : "";
 
     const volunteerDetails =
-      `:wave: ${volunteerLink}\n` +
+      `:wave:${hasCar} ${volunteerLink}\n` +
       `:pushpin: ${displayNumber} - ${volunteerDistance}\n` +
       `:speaking_head_in_silhouette: ${volunteerLanguage}\n` +
       `:chart_with_upwards_trend: ${displayStats.count} ${displayStats.lastDate}\n`;


### PR DESCRIPTION
Output a car emoji to the volunteer listing when that person owns a car.
This makes it easier for dispatchers to co-ordinate.