### PR TITLE
Improving error handling to avoid duplicate messages being sent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,7 @@ build: ## Build Docker services.
 
 run: ## Start Docker services.
 	docker-compose up
+
+pr: ## Prepare for pull request
+	npm run lint
+	npm run test

--- a/src/index.js
+++ b/src/index.js
@@ -235,12 +235,21 @@ async function checkForNewSubmissions() {
 
         logger.info(`New help request for: ${requestWithCoords.get("Name")}`);
 
-        // Can be an async operation
-        // noinspection ES6MissingAwait - no need to wait for a response.
-        requestService.linkUserWithRequest(record);
+        try {
+          // Can be an async operation
+          // noinspection ES6MissingAwait - no need to wait for a response.
+          requestService.linkUserWithRequest(record);
+        } catch (e) {
+          logger.error("Unable to link user with request ", e);
+        }
 
-        // Find the closest volunteers
-        const volunteers = await findVolunteers(requestWithCoords);
+        let volunteers;
+        try {
+          // Find the closest volunteers
+          volunteers = await findVolunteers(requestWithCoords);
+        } catch (e) {
+          logger.error("Unable to find volunteers for request ", e);
+        }
 
         // Send the message to Slack
         let messageSent = false;


### PR DESCRIPTION
- If an error happens, nothing should get sent to Slack.
- Also, an error with a single record shouldn't prevent further processing (of later records).
