### PR TITLE
Check for Twilio credentials before attempting to send a followup text

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -301,7 +301,8 @@ async function checkForNewSubmissions() {
   const authToken = config.TWILIO_AUTH_TOKEN;
   const client = require("twilio")(accountSid, authToken);
   const twilioPhoneNumber = config.TWILIO_PHONE_NUMBER;
-  const hasTwilioCredentials = accountSid && authToken && twilioPhoneNumber;
+  const hasTwilioCredentials =
+    (accountSid && authToken && twilioPhoneNumber) || false;
 
   // Check Airtable for tasks completed in the last day, then send volunteer
   // a followup text

--- a/src/index.js
+++ b/src/index.js
@@ -296,6 +296,13 @@ async function checkForNewSubmissions() {
       nextPage();
     });
 
+  // Check if Twilio credentials are present, in order to send followup text
+  const accountSid = config.TWILIO_ACCOUNT_SID;
+  const authToken = config.TWILIO_AUTH_TOKEN;
+  const client = require("twilio")(accountSid, authToken);
+  const twilioPhoneNumber = config.TWILIO_PHONE_NUMBER;
+  const hasTwilioCredentials = accountSid && authToken && twilioPhoneNumber;
+
   // Check Airtable for tasks completed in the last day, then send volunteer
   // a followup text
   base(config.AIRTABLE_REQUESTS_TABLE_NAME)
@@ -322,48 +329,53 @@ async function checkForNewSubmissions() {
             logger.error(err);
             return;
           }
-          const accountSid = config.TWILIO_ACCOUNT_SID;
-          const authToken = config.TWILIO_AUTH_TOKEN;
-          const client = require("twilio")(accountSid, authToken);
           const phoneNumber = rec.get(
             "Please provide your contact phone number:"
           );
           const formattedPhoneNumber = formatPhoneNumber(phoneNumber);
 
-          logger.info(`Sending followup text to: ${formattedPhoneNumber}`);
-          client.messages
-            .create({
-              body: "Thank you for being a great neighbor!",
-              from: config.TWILIO_PHONE_NUMBER,
-              to: formattedPhoneNumber,
-            })
-            .then((message) => {
-              logger.info(`Message SID: ${message.sid}`);
-              base(config.AIRTABLE_REQUESTS_TABLE_NAME).update(
-                [
-                  {
-                    id: record.id,
-                    fields: {
-                      "Followup SMS Sent?": "Yes",
+          if (hasTwilioCredentials) {
+            logger.info(`Sending followup text to: ${formattedPhoneNumber}`);
+            client.messages
+              .create({
+                body: "Thank you for being a great neighbor!",
+                from: config.TWILIO_PHONE_NUMBER,
+                to: formattedPhoneNumber,
+              })
+              .then((message) => {
+                logger.info(`Message SID: ${message.sid}`);
+                base(config.AIRTABLE_REQUESTS_TABLE_NAME).update(
+                  [
+                    {
+                      id: record.id,
+                      fields: {
+                        "Followup SMS Sent?": "Yes",
+                      },
                     },
-                  },
-                ],
-                function (err, records) {
-                  if (err) {
-                    logger.error(err);
-                    return;
+                  ],
+                  function (err, records) {
+                    if (err) {
+                      logger.error(err);
+                      return;
+                    }
+                    records.forEach(function (record) {
+                      logger.info(
+                        `Followup text sent?: ${record.get(
+                          "Followup SMS Sent?"
+                        )}`
+                      );
+                    });
                   }
-                  records.forEach(function (record) {
-                    logger.info(
-                      `Followup text sent?: ${record.get("Followup SMS Sent?")}`
-                    );
-                  });
-                }
-              );
-            })
-            .catch((error) => {
-              logger.error(`onRejected function called: ${error.message}`);
-            });
+                );
+              })
+              .catch((error) => {
+                logger.error(`onRejected function called: ${error.message}`);
+              });
+          } else {
+            logger.error(
+              "Twilio credentials missing -- Followup text not sent"
+            );
+          }
         });
       }
       nextPage();


### PR DESCRIPTION
This PR adds a flag `hasTwilioCredentials` that checks for the presence of the necessary Twilio credentials (`TWILIO_ACCOUNT_SID`, 
  `TWILIO_AUTH_TOKEN`, `TWILIO_PHONE_NUMBER`) in order to send a followup text to volunteers upon task completion. 

If the credentials are present, `hasTwilioCredentials` is set to `true`, and the bot attempts to send a followup text to the volunteer.
If any credentials are missing, `hasTwilioCredentials` is set to `false`, and the bot logs the following error: `Twilio credentials missing -- Followup text not sent`.

⚠️ In order to test this update, the Airtable schema changes in #67 will need to be implemented. ⚠️