### PR TITLE
Fix backfillRequesters script

### DIFF
--- a/scripts/oneoff/backfillRequesters.js
+++ b/scripts/oneoff/backfillRequesters.js
@@ -47,7 +47,7 @@ async function backfillRequesters() {
           await requestService.linkUserWithRequest(record);
           successCount++;
           logger.info(
-            `succesfully processed: ${successCount} of ${totalCount + 1}`
+            `successfully processed ${successCount} of ${totalCount + 1}`
           );
         } catch (err) {
           errors.push({

--- a/scripts/oneoff/backfillRequesters.js
+++ b/scripts/oneoff/backfillRequesters.js
@@ -5,6 +5,7 @@ const config = require("../../src/config");
 const Request = require("../../src/model/request-record");
 const RequesterService = require("../../src/service/requester-service");
 const RequestService = require("../../src/service/request-service");
+const { logger } = require("../../src/logger");
 
 const base = new Airtable({ apiKey: config.AIRTABLE_API_KEY }).base(
   config.AIRTABLE_BASE_ID
@@ -26,7 +27,10 @@ const requestService = new RequestService(
  * @returns {void}
  */
 async function backfillRequesters() {
-  base(config.AIRTABLE_REQUESTS_TABLE_NAME)
+  const errors = [];
+  let totalCount = 0;
+  let successCount = 0;
+  await base(config.AIRTABLE_REQUESTS_TABLE_NAME)
     .select({
       view: config.AIRTABLE_REQUESTS_VIEW_NAME,
       filterByFormula: `{Requester} = ''`,
@@ -35,11 +39,33 @@ async function backfillRequesters() {
       if (!records.length) return;
       const mappedRecords = records.map((r) => new Request(r));
       for (const record of mappedRecords) {
-        await requestService.linkUserWithRequest(record);
+        const requesterName = record.get("Name");
+        const phoneNumber = record.get("Phone number");
+        logger.info(`Now processing:`);
+        logger.info(`id: ${record.id}`);
+        try {
+          await requestService.linkUserWithRequest(record);
+          successCount++;
+          logger.info(
+            `succesfully processed: ${successCount} of ${totalCount + 1}`
+          );
+        } catch (err) {
+          errors.push({
+            id: record.id,
+            name: requesterName,
+            phone: phoneNumber,
+            error: err,
+          });
+          logger.error(err);
+        }
+        totalCount++;
+        console.log("");
       }
 
       nextPage();
     });
+  logger.info(`successfully processed ${successCount} of ${totalCount}`);
+  console.log("errors", errors);
 }
 
 backfillRequesters();

--- a/src/service/requester-service.js
+++ b/src/service/requester-service.js
@@ -43,11 +43,10 @@ class RequesterService {
    */
   async findUserByPhoneNumber(phoneNumber) {
     preconditions.shouldBeString(phoneNumber);
-    const phoneNumberToSearch = phoneNumberUtil.getDisplayNumber(phoneNumber);
     const records = await this.base
       .select({
         view: config.AIRTABLE_USERS_VIEW_NAME,
-        filterByFormula: `{Phone Number} = '${phoneNumberToSearch}'`,
+        filterByFormula: `{Phone Number} = "${phoneNumber}"`,
       })
       .firstPage();
     return extractUserRecordIfAvailable(phoneNumber, records);
@@ -62,10 +61,17 @@ class RequesterService {
   async findUserByFullName(fullName) {
     preconditions.shouldBeString(fullName);
     // eslint-disable-next-line prefer-const
+    let searchName = fullName;
+
+    // Escape double quotes in name
+    if (fullName.includes('"')) {
+      searchName = fullName.replace(/"/g, '\\"');
+    }
+
     const records = await this.base
       .select({
         view: config.AIRTABLE_USERS_VIEW_NAME,
-        filterByFormula: `{Full Name} = '${fullName}'`,
+        filterByFormula: `{Full Name} = "${searchName}"`,
       })
       .firstPage();
     return extractUserRecordIfAvailable(fullName, records);

--- a/test/service/requester-service.test.js
+++ b/test/service/requester-service.test.js
@@ -1,5 +1,4 @@
 const RequesterService = require("../../src/service/requester-service");
-const phoneNumberUtils = require("../../src/utils/phone-number-utils");
 
 jest.mock("../../src/utils/phone-number-utils");
 jest.mock("../../src/config", () => {
@@ -10,7 +9,7 @@ jest.mock("../../src/config", () => {
 const mockUsersViewName = "Grid View";
 
 const fullName = "Ezekiel Adams";
-const phoneNumber = "055.956.1902";
+const phoneNumber = "(055) 956-1902";
 const records = [
   {
     get: (field) => {
@@ -39,7 +38,6 @@ describe("RequesterService", () => {
       select: mockSelect,
     };
     service = new RequesterService(base);
-    phoneNumberUtils.getDisplayNumber.mockReturnValue(phoneNumber);
   });
   describe("findUserByPhoneNumber", () => {
     it("should check is supplied argument is a string", async () => {
@@ -53,15 +51,12 @@ describe("RequesterService", () => {
         "Variable should be a String."
       );
     });
-    const expectedFilterByFormula = `{Phone Number} = '${phoneNumber}'`;
+    const expectedFilterByFormula = `{Phone Number} = "${phoneNumber}"`;
     it("should throw error if more than one records are found for given number", async () => {
-      expect.assertions(3);
+      expect.assertions(2);
       mockFirstPage.mockReturnValue([records[0], records[1]]);
       await expect(service.findUserByPhoneNumber(phoneNumber)).rejects.toThrow(
         `${phoneNumber} has more than one user linked to it!`
-      );
-      expect(phoneNumberUtils.getDisplayNumber).toHaveBeenCalledWith(
-        phoneNumber
       );
       expect(mockSelect).toHaveBeenCalledWith({
         view: mockUsersViewName,
@@ -69,12 +64,9 @@ describe("RequesterService", () => {
       });
     });
     it("should throw return null if no users found for given phone number", async () => {
-      expect.assertions(3);
+      expect.assertions(2);
       mockFirstPage.mockReturnValue([]);
       const userRecord = await service.findUserByPhoneNumber(phoneNumber);
-      expect(phoneNumberUtils.getDisplayNumber).toHaveBeenCalledWith(
-        phoneNumber
-      );
       expect(mockSelect).toHaveBeenCalledWith({
         view: mockUsersViewName,
         filterByFormula: expectedFilterByFormula,
@@ -82,12 +74,9 @@ describe("RequesterService", () => {
       expect(userRecord).toBe(null);
     });
     it("should search for users with formatted phone number", async () => {
-      expect.assertions(4);
+      expect.assertions(3);
       mockFirstPage.mockReturnValue(records);
       const userRecord = await service.findUserByPhoneNumber(phoneNumber);
-      expect(phoneNumberUtils.getDisplayNumber).toHaveBeenCalledWith(
-        phoneNumber
-      );
       expect(mockSelect).toHaveBeenCalledWith({
         view: mockUsersViewName,
         filterByFormula: expectedFilterByFormula,
@@ -108,7 +97,8 @@ describe("RequesterService", () => {
         "Variable should be a String."
       );
     });
-    const expectedFilterByFormula = `{Full Name} = '${fullName}'`;
+    const searchName = fullName.replace(/"/g, '\\"');
+    const expectedFilterByFormula = `{Full Name} = "${searchName}"`;
     it("should throw error if more than one records are found for given full name", async () => {
       expect.assertions(2);
       mockFirstPage.mockReturnValue([records[0], records[1]]);


### PR DESCRIPTION
This PR addresses a bug that had been creating duplicate entries for the same requester in the `Requesters` table. 

## **Background**
- Every record in `Requests` table is linked to a corresponding record in `Requesters` table. A single `requester` may have many `requests`.
- When linking a `request` from the `Requests` table to a record in the `Requesters` table, the bot searches `Requesters` table for a matching record, first by requester's phone number, and if no match, then by full name. 
- If still no matching record, the bot creates a new record in `Requesters` and links the `request` to it. 
- Searching first by phone number allows us to link new `requests` with an existing `Requesters` record even if there are typos or spelling variations in the name.
- The bug causes `findUserByPhoneNumber` to return no records from `Requesters` even if there is a match, therefore creating a duplicate entry in `Requesters` for the same `Phone Number`, and potentially also the same `Full Name`.
- Any further (or retroactive through backfilling)`requests` by the same requester will trigger an error, as multiple records in `Requesters` will match the same phone number, and the bot won't know which record to link the `request` to.
