### PR TITLE
Create script to remove extra whitespace from record values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -918,6 +918,11 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/node": {
+      "version": "14.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+    },
     "@types/prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
@@ -995,6 +1000,19 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "abortcontroller-polyfill": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz",
+      "integrity": "sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -1041,63 +1059,21 @@
       "dev": true
     },
     "airtable": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.8.1.tgz",
-      "integrity": "sha512-Cxw55ta1olDwDERz++HFJOBX6LONtg+d7+wOcYguqI4PR4P5RHmgjTbY8tPKgLHb8U3FVOyAbpb7NpLRSnLGgg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.10.0.tgz",
+      "integrity": "sha512-6gBUG+z1kqvwyHYWlc+y74TfYpc18mvmNuVcefjlvd6MSgLP9Hk47ByyBS6Ke8zdSk6kBTDpdiwCjoJQUpu6yg==",
       "requires": {
-        "es6-promise": "4.2.8",
-        "lodash": "4.17.15",
-        "request": "2.88.0",
-        "xhr": "2.3.3"
+        "@types/node": "^14.0.14",
+        "abort-controller": "^3.0.0",
+        "abortcontroller-polyfill": "^1.4.0",
+        "lodash": "4.17.19",
+        "node-fetch": "^2.6.0"
       },
       "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "qs": {
-              "version": "6.5.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-            }
-          }
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         }
       }
     },
@@ -1914,6 +1890,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "condense-whitespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/condense-whitespace/-/condense-whitespace-2.0.0.tgz",
+      "integrity": "sha512-Ath9o58/0rxZXbyoy3zZgrVMoIemi30sukG/btuMKCLyqfQt3dNOWc9N3EHEMa2Q3i0tXQPDJluYFLwy7pJuQw=="
+    },
     "configstore": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
@@ -2211,11 +2192,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -2226,9 +2202,9 @@
       }
     },
     "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
@@ -2345,11 +2321,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2658,6 +2629,11 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -3236,15 +3212,6 @@
         "is-glob": "^4.0.1"
       }
     },
-    "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
-      }
-    },
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -3787,11 +3754,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
-    },
-    "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -5783,9 +5745,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -5925,14 +5887,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -6082,6 +6036,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-geocoder": {
       "version": "3.25.1",
@@ -6422,11 +6381,6 @@
         "callsites": "^3.0.0"
       }
     },
-    "parse-headers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
-    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -6618,11 +6572,6 @@
           "dev": true
         }
       }
-    },
-    "process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -8580,17 +8529,6 @@
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
-    "xhr": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.3.3.tgz",
-      "integrity": "sha1-rWuBDgkXznK17HBPXUHxUDuOdSQ=",
-      "requires": {
-        "global": "~4.3.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -8602,11 +8540,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "nodemon src/index.js",
     "lint": "eslint src/**/*.js test/**/*.js",
     "lint:fix": "eslint src/**/*.js test/**/*.js --fix",
-    "backfill-requesters": "node scripts/oneoff/backfillRequesters.js"
+    "backfill-requesters": "node scripts/oneoff/backfillRequesters.js",
+    "remove-extra-whitespace": "node scripts/oneoff/removeExtraWhitespace.js"
   },
   "repository": {
     "type": "git",
@@ -22,9 +23,10 @@
   },
   "homepage": "https://github.com/astoria-tech/slack-volunteer-seeker#readme",
   "dependencies": {
-    "airtable": "^0.8.1",
+    "airtable": "^0.10.0",
     "axios": "^0.19.2",
     "body-parser": "^1.19.0",
+    "condense-whitespace": "^2.0.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "geolib": "^3.2.1",

--- a/scripts/oneoff/removeExtraWhitespace.js
+++ b/scripts/oneoff/removeExtraWhitespace.js
@@ -1,0 +1,110 @@
+const Airtable = require("airtable");
+const condenseWhitespace = require("condense-whitespace");
+
+const config = require("../../src/config");
+const { logger } = require("../../src/logger");
+
+const base = new Airtable({ apiKey: config.AIRTABLE_API_KEY }).base(
+  config.AIRTABLE_BASE_ID
+);
+
+/**
+ * Checks table for records that contain extra whitespace and removes the extra
+ * whitespace
+ *
+ * @returns {void}
+ * @param {string} tableName - Name of table to check for extra whitespace
+ * @param {string} fieldName - Name of field to check for extra whitespace
+ */
+async function removeExtraWhitespace(tableName, fieldName) {
+  if (process.argv.length < 3) {
+    logger.error("Incorrect number of arguments");
+  }
+
+  const errors = [];
+  let table;
+  let view;
+  let updatedCount = 0;
+  let totalCount = 0;
+  if (tableName.toLowerCase() === "requests") {
+    table = config.AIRTABLE_REQUESTS_TABLE_NAME;
+    view = config.AIRTABLE_REQUESTS_VIEW_NAME;
+  } else if (tableName.toLowerCase() === "volunteers") {
+    table = config.AIRTABLE_VOLUNTEERS_TABLE_NAME;
+    view = config.AIRTABLE_VOLUNTEERS_VIEW_NAME;
+  } else {
+    throw new Error(`Invalid table name: ${tableName}`);
+  }
+
+  await base(table)
+    .select({
+      view,
+      filterByFormula: `OR(
+        LEFT({${fieldName}}, 1) = " ",
+        RIGHT({${fieldName}}, 1) = " ",
+        FIND("  ", {${fieldName}}) > 0
+      )`,
+    })
+    .eachPage(async (records, nextPage) => {
+      if (!records.length) {
+        logger.info("No records require updating");
+        return;
+      }
+      for (const record of records) {
+        logger.info(`Now processing:`);
+        logger.info(`id: ${record.id}`);
+        let currentValue;
+        try {
+          currentValue = await record.get(fieldName);
+          if (!currentValue) {
+            throw new Error("Invalid field name");
+          }
+        } catch (err) {
+          logger.error(err);
+          return;
+        }
+
+        const condensedValue = condenseWhitespace(currentValue);
+        const extraSpace = currentValue.length - condensedValue.length;
+
+        try {
+          await base(table).update(
+            record.id,
+            { [fieldName]: condensedValue },
+            function (err) {
+              if (err) {
+                logger.error(err);
+              }
+            }
+          );
+        } catch (err) {
+          errors.push({
+            id: record.id,
+            name: currentValue,
+            error: err,
+          });
+          logger.error(err);
+        }
+        logger.info(
+          `Removed ${extraSpace} extra space${extraSpace > 1 ? "s" : ""}`
+        );
+        updatedCount += 1;
+        totalCount += 1;
+        console.log("");
+      }
+      nextPage();
+    })
+    .catch((err) => {
+      console.log("are we here?");
+      return logger.error(err);
+    });
+  logger.info(`Successfully updated ${updatedCount} of ${totalCount} records`);
+  if (errors.length > 0) {
+    logger.info(`${errors.length} error${errors.length === 1 ? "" : "s"}`);
+    console.log("errors", errors);
+  }
+}
+
+removeExtraWhitespace(process.argv[2], process.argv[3]).catch((err) =>
+  logger.error(err)
+);


### PR DESCRIPTION
This PR adds a script that removes extra whitespace from fields in `Requests` and `Volunteers` tables that contain string values. Leading whitespace, trailing whitespace, or multiple consecutive spaces in a string are all considered extra whitespace.

## Usage
To run the script, open the command line to the project directory and execute the following:
`npm run remove-extra-whitespace [tableName] [fieldName]`

### Examples
- `npm run remove-extra-whitespace requests Name`
- `npm run remove-extra-whitespace requests "Phone number"`
- `npm run remove-extra-whitespace volunteers "First Name"`
- `npm run remove-extra-whitespace volunteers "Last Name"`
- `npm run remove-extra-whitespace volunteers "Please provide your contact phone number:"`